### PR TITLE
Cleaned up implementation of #48.

### DIFF
--- a/src/main/java/org/worldcubeassociation/workbook/Format.java
+++ b/src/main/java/org/worldcubeassociation/workbook/Format.java
@@ -13,9 +13,9 @@ public enum Format {
 
     private int fResultCount;
     private String fDisplayName;
-    private Object fCode;
+    private String fCode;
 
-    private Format(String aDisplayName, int aResultCount, Object aCode) {
+    private Format(String aDisplayName, int aResultCount, String aCode) {
         fDisplayName = aDisplayName;
         fResultCount = aResultCount;
         fCode = aCode;
@@ -30,7 +30,7 @@ public enum Format {
         return fDisplayName;
     }
 
-    public Object getCode() {
+    public String getCode() {
         return fCode;
     }
 }

--- a/src/main/java/org/worldcubeassociation/workbook/Round.java
+++ b/src/main/java/org/worldcubeassociation/workbook/Round.java
@@ -18,11 +18,11 @@ public enum Round {
     FINAL("Final", "f", 6, false);
 
     private String fDisplayName;
-    private Object fCode;
+    private String fCode;
     private int fRoundType;
     private boolean fCombined;
 
-    private Round(String aDisplayName, Object aCode, int aRoundType, boolean aCombined) {
+    private Round(String aDisplayName, String aCode, int aRoundType, boolean aCombined) {
         fDisplayName = aDisplayName;
         fCode = aCode;
         fRoundType = aRoundType;
@@ -34,7 +34,7 @@ public enum Round {
         return fDisplayName;
     }
 
-    public Object getCode() {
+    public String getCode() {
         return fCode;
     }
 

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/TNoodleSheetJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/TNoodleSheetJson.java
@@ -1,6 +1,7 @@
 package org.worldcubeassociation.workbook.scrambles;
 
 import org.worldcubeassociation.workbook.MatchedSheet;
+import org.worldcubeassociation.workbook.wcajson.WcaGroupJson;
 
 public class TNoodleSheetJson {
 	public String[] scrambles;
@@ -13,8 +14,8 @@ public class TNoodleSheetJson {
 	public String event;
 	public int round;
 	
-	public WcaSheetJson toWcaSheetJson(MatchedSheet matchedSheet) {
-		WcaSheetJson wcaSheet = new WcaSheetJson();
+	public WcaGroupJson toWcaSheetJson(MatchedSheet matchedSheet) {
+		WcaGroupJson wcaSheet = new WcaGroupJson();
 		wcaSheet.scrambles = scrambles;
 		wcaSheet.extraScrambles = extraScrambles;
 		wcaSheet.group = group;

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/WcaSheetJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/WcaSheetJson.java
@@ -1,9 +1,0 @@
-package org.worldcubeassociation.workbook.scrambles;
-
-public class WcaSheetJson {
-	public String[] scrambles;
-	public String[] extraScrambles;
-	public Object round;
-	public String group;
-	public String event;
-}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaCompetitionJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaCompetitionJson.java
@@ -1,0 +1,12 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaCompetitionJson {
+	public String formatVersion;
+	public String competitionId;
+	public WcaPersonJson[] persons;
+	public WcaEventJson[] events;
+	public String scrambleProgram;
+}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaEventJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaEventJson.java
@@ -1,0 +1,9 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaEventJson {
+	public String eventId;
+	public WcaRoundJson[] rounds;
+}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaGroupJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaGroupJson.java
@@ -1,0 +1,10 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaGroupJson {
+	public String group;
+	public String[] scrambles;
+	public String[] extraScrambles;
+}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaPersonJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaPersonJson.java
@@ -1,0 +1,13 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaPersonJson {
+	public int id;
+	public String name;
+	public String wcaId;
+	public String countryId;
+	public String gender;
+	public String dob;
+}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaResultJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaResultJson.java
@@ -1,0 +1,12 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaResultJson {
+	public int personId;
+	public int position;
+	public long[] results;
+	public long best;
+	public long average;
+}

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaRoundJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaRoundJson.java
@@ -1,0 +1,11 @@
+package org.worldcubeassociation.workbook.wcajson;
+
+/*
+ * See documentation here https://github.com/cubing/wca-workbook-assistant/issues/48#issue-16730558
+ */
+public class WcaRoundJson {
+	public String roundId;
+	public String formatId;
+	public WcaResultJson[] results;
+	public WcaGroupJson[] groups;
+}


### PR DESCRIPTION
Yay static typing! I think I found a bug with the position attribute. It was a String in the old code, I've changed it to an int.

I took the liberty of changing the json spec on https://github.com/cubing/wca-workbook-assistant/issues/48:
1. renamed the top level object from Result -> Competition (note, this doesn't actually effect the resulting json)
2. "results" attribute renamed to "events"

I put all the wca json models in a new org.worldcubeassociation.workbook.wcajson package. They should match the specification on #48 perfectly.

I ran into an issue with the tsv parsing. I didn't really look into it, just changed the code to add the lines with asterisks (that last call to scanner.next() was crashing for me, I'm on Windows, so it might be a line ending thing)

```
Scanner scanner = new Scanner(countriesStream, "UTF-8");
scanner.useDelimiter("[\t\n\r\f]");
while (scanner.hasNext()) {
    String countryId = scanner.next();
    String iso3166Code = scanner.next();
    if(scanner.hasNext()) { // ***************
        scanner.next();
    } // ***************
    sCountryCodes.put(countryId, iso3166Code);
}
scanner.close();
```
