### PR TITLE
If all the cells are filled in on a combined round, complain! fixes #40.

### DIFF
--- a/src/main/java/org/worldcubeassociation/workbook/WorkbookValidator.java
+++ b/src/main/java/org/worldcubeassociation/workbook/WorkbookValidator.java
@@ -407,7 +407,8 @@ public class WorkbookValidator {
         int nbDataRows = aMatchedSheet.getLastDataRow() - aMatchedSheet.getFirstDataRow() + 1;
         Long[] bestResults = new Long[nbDataRows];
         Long[] averageResults = new Long[nbDataRows];
-
+        boolean allCellsPresent = true;
+        
         for (int rowIdx = 0; rowIdx < nbDataRows; rowIdx++) {
             Row row = sheet.getRow(rowIdx + aMatchedSheet.getFirstDataRow());
             int sheetRow = rowIdx + aMatchedSheet.getFirstDataRow();
@@ -449,6 +450,10 @@ public class WorkbookValidator {
                     allResultsInRowValid = false;
                     allRowsValid = false;
                 }
+            }
+            
+            if(!allResultsInRowPresent) {
+            	allCellsPresent = false;
             }
 
             // For multiple blindfolded, check that the score is calculated correctly.
@@ -697,6 +702,13 @@ public class WorkbookValidator {
                     validationErrors.add(new ValidationError(Severity.HIGH, "Misformatted average record", aMatchedSheet, sheetRow, averageRecordCellCol));
                 }
             }
+        }
+        
+        if(allCellsPresent) {
+        	// If all time cells were filled in, the format of the round should *not* be combined.
+        	if(aMatchedSheet.getRound().isCombined()) {
+        		validationErrors.add(new ValidationError(Severity.HIGH, "Sheet with all cells filled in should not be a combined format", aMatchedSheet, -1, -1));
+        	}
         }
 
         // Check sorting.


### PR DESCRIPTION
I noticed that combined rounds don't check _which_ solves were entered, all they require is that the very first time be entered. Here's the relevant code from WorkbookValidator:

``` java
Long result;
if (round.isCombined() && resultIdx > 1) {
    result = CellParser.parseOptionalSingleTime(resultCell, resultFormat, event, aFormulaEvaluator);
}
else {
    result = CellParser.parseMandatorySingleTime(resultCell, resultFormat, event, aFormulaEvaluator);
}
results[resultIdx - 1] = result;
```

Ideally, we'd assert that all the incomplete rows have the same number of solves entered, and that there aren't any gaps in that range.
