### PR TITLE
Fix for #73 + some misc stuff

### DIFF
--- a/src/main/java/org/worldcubeassociation/WorkbookAssistantEnv.java
+++ b/src/main/java/org/worldcubeassociation/WorkbookAssistantEnv.java
@@ -22,7 +22,7 @@ public class WorkbookAssistantEnv {
     public static final String SHEETS_CHANGED = "sheetsChanged";
     public static final String DATABASE = "database";
     public static final String FONT_SIZE = "fontSize";
-    public static final String SCRAMBLES = "database";
+    public static final String SCRAMBLES = "scrambles";
 
     private float fFontSize;
 

--- a/src/main/java/org/worldcubeassociation/ui/EditScramblesAction.java
+++ b/src/main/java/org/worldcubeassociation/ui/EditScramblesAction.java
@@ -1,0 +1,64 @@
+package org.worldcubeassociation.ui;
+
+import java.awt.Dialog;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.AbstractAction;
+
+import org.worldcubeassociation.WorkbookAssistantEnv;
+import org.worldcubeassociation.ui.tree.TreeDragAndDrop;
+import org.worldcubeassociation.workbook.scrambles.Scrambles;
+
+/**
+ * Let the user move scrambles between ScrambleRounds.
+ */
+public class EditScramblesAction extends AbstractAction implements PropertyChangeListener {
+
+    private final WorkbookAssistantEnv fEnv;
+    private NicelySizedJDialog fDialog;
+    private TreeDragAndDrop scrambleTree;
+
+    public EditScramblesAction(WorkbookAssistantEnv aEnv) {
+        super("Edit");
+        fEnv = aEnv;
+        aEnv.addPropertyChangeListener(this);
+        initUI();
+        updateEnabledState();
+        
+    }
+
+    private void updateEnabledState() {
+        Scrambles scrambles = fEnv.getScrambles();
+        boolean anyScrambles = scrambles != null && scrambles.getDecodedScrambleFiles().size() > 0;
+        setEnabled(anyScrambles);
+    }
+
+    private void initUI() {
+        fDialog = new NicelySizedJDialog(fEnv.getTopLevelComponent(), "Edit scrambles", Dialog.ModalityType.APPLICATION_MODAL);
+        
+        scrambleTree = new TreeDragAndDrop(fEnv);
+        fDialog.getContentPane().add(scrambleTree.getContent());
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent event) {
+
+        scrambleTree.expandTree();
+        fDialog.pack();
+        
+        fDialog.setLocationRelativeTo(fEnv.getTopLevelComponent());
+        fDialog.setVisible(true);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (WorkbookAssistantEnv.SCRAMBLES.equals(e.getPropertyName())) {
+            updateEnabledState();
+        }
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/GenerateJSONAction.java
+++ b/src/main/java/org/worldcubeassociation/ui/GenerateJSONAction.java
@@ -2,20 +2,15 @@ package org.worldcubeassociation.ui;
 
 import java.awt.Dialog;
 import java.awt.Font;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
-import java.io.*;
-import java.util.ArrayList;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Arrays;
 
 import javax.swing.AbstractAction;
@@ -47,27 +42,7 @@ public class GenerateJSONAction extends AbstractGenerateAction implements Proper
     }
 
     private void initUI() {
-    	// Without this magic, on Windows, JDialog's will be resized so large that they
-    	// get hidden underneath the task bar. See http://stackoverflow.com/a/6422995
-        fDialog = new JDialog(getEnv().getTopLevelComponent(), "Generate competition JSON", Dialog.ModalityType.APPLICATION_MODAL) {
-            @Override
-            public void setBounds(int x, int y, int width, int height) {
-                Rectangle bounds = getSafeScreenBounds(new Point(x, y));
-                if (x < bounds.x) {
-                    x = bounds.x;
-                }
-                if (y < bounds.y) {
-                    y = bounds.y;
-                }
-                if (width > bounds.width) {
-                    width = (bounds.x + bounds.width) - x;
-                }
-                if (height > bounds.height) {
-                    height = (bounds.y + bounds.height) - y;
-                }
-                super.setBounds(x, y, width, height);
-            }
-        };
+        fDialog = new NicelySizedJDialog(getEnv().getTopLevelComponent(), "Generate competition JSON", Dialog.ModalityType.APPLICATION_MODAL);
         fDialog.getContentPane().setLayout(new GridBagLayout());
 
         GridBagConstraints c = new GridBagConstraints();
@@ -102,71 +77,6 @@ public class GenerateJSONAction extends AbstractGenerateAction implements Proper
         fDialog.pack();
     }
     
-
-    public static Rectangle getSafeScreenBounds(Point pos) {
-
-        Rectangle bounds = getScreenBoundsAt(pos);
-        Insets insets = getScreenInsetsAt(pos);
-
-        bounds.x += insets.left;
-        bounds.y += insets.top;
-        bounds.width -= (insets.left + insets.right);
-        bounds.height -= (insets.top + insets.bottom);
-
-        return bounds;
-
-    }
-
-    public static Insets getScreenInsetsAt(Point pos) {
-        GraphicsDevice gd = getGraphicsDeviceAt(pos);
-        Insets insets = null;
-        if (gd != null) {
-            insets = Toolkit.getDefaultToolkit().getScreenInsets(gd.getDefaultConfiguration());
-        }
-        return insets;
-    }
-
-    public static Rectangle getScreenBoundsAt(Point pos) {
-        GraphicsDevice gd = getGraphicsDeviceAt(pos);
-        Rectangle bounds = null;
-        if (gd != null) {
-            bounds = gd.getDefaultConfiguration().getBounds();
-        }
-        return bounds;
-    }
-
-    public static GraphicsDevice getGraphicsDeviceAt(Point pos) {
-
-        GraphicsDevice device = null;
-
-        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        GraphicsDevice lstGDs[] = ge.getScreenDevices();
-
-        ArrayList<GraphicsDevice> lstDevices = new ArrayList<GraphicsDevice>(lstGDs.length);
-
-        for (GraphicsDevice gd : lstGDs) {
-
-            GraphicsConfiguration gc = gd.getDefaultConfiguration();
-            Rectangle screenBounds = gc.getBounds();
-
-            if (screenBounds.contains(pos)) {
-
-                lstDevices.add(gd);
-
-            }
-
-        }
-
-        if (lstDevices.size() > 0) {
-            device = lstDevices.get(0);
-        } else {
-            device = ge.getDefaultScreenDevice();
-        }
-
-        return device;
-
-    }
-
     @Override
     public void actionPerformed(ActionEvent aActionEvent) {
         boolean approved = warnForErrors(Arrays.asList(SheetType.values()));

--- a/src/main/java/org/worldcubeassociation/ui/NicelySizedJDialog.java
+++ b/src/main/java/org/worldcubeassociation/ui/NicelySizedJDialog.java
@@ -1,0 +1,106 @@
+package org.worldcubeassociation.ui;
+
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.util.ArrayList;
+
+import javax.swing.JDialog;
+
+public class NicelySizedJDialog extends JDialog {
+    
+    public NicelySizedJDialog(Window topLevelComponent, String title, ModalityType applicationModal) {
+        super(topLevelComponent, title, applicationModal);
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+        // Without this magic, on Windows, JDialog's will be resized so large that they
+        // get hidden underneath the task bar. See http://stackoverflow.com/a/6422995
+        
+        Rectangle bounds = getSafeScreenBounds(new Point(x, y));
+        if (x < bounds.x) {
+            x = bounds.x;
+        }
+        if (y < bounds.y) {
+            y = bounds.y;
+        }
+        if (width > bounds.width) {
+            width = (bounds.x + bounds.width) - x;
+        }
+        if (height > bounds.height) {
+            height = (bounds.y + bounds.height) - y;
+        }
+        super.setBounds(x, y, width, height);
+    }
+
+    public static Rectangle getSafeScreenBounds(Point pos) {
+
+        Rectangle bounds = getScreenBoundsAt(pos);
+        Insets insets = getScreenInsetsAt(pos);
+
+        bounds.x += insets.left;
+        bounds.y += insets.top;
+        bounds.width -= (insets.left + insets.right);
+        bounds.height -= (insets.top + insets.bottom);
+
+        return bounds;
+
+    }
+
+    public static Insets getScreenInsetsAt(Point pos) {
+        GraphicsDevice gd = getGraphicsDeviceAt(pos);
+        Insets insets = null;
+        if (gd != null) {
+            insets = Toolkit.getDefaultToolkit().getScreenInsets(gd.getDefaultConfiguration());
+        }
+        return insets;
+    }
+
+    public static Rectangle getScreenBoundsAt(Point pos) {
+        GraphicsDevice gd = getGraphicsDeviceAt(pos);
+        Rectangle bounds = null;
+        if (gd != null) {
+            bounds = gd.getDefaultConfiguration().getBounds();
+        }
+        return bounds;
+    }
+
+    public static GraphicsDevice getGraphicsDeviceAt(Point pos) {
+
+        GraphicsDevice device = null;
+
+        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice lstGDs[] = ge.getScreenDevices();
+
+        ArrayList<GraphicsDevice> lstDevices = new ArrayList<GraphicsDevice>(lstGDs.length);
+
+        for (GraphicsDevice gd : lstGDs) {
+
+            GraphicsConfiguration gc = gd.getDefaultConfiguration();
+            Rectangle screenBounds = gc.getBounds();
+
+            if (screenBounds.contains(pos)) {
+
+                lstDevices.add(gd);
+
+            }
+
+        }
+
+        if (lstDevices.size() > 0) {
+            device = lstDevices.get(0);
+        } else {
+            device = ge.getDefaultScreenDevice();
+        }
+
+        return device;
+
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/WorkbookAssistantFrame.java
+++ b/src/main/java/org/worldcubeassociation/ui/WorkbookAssistantFrame.java
@@ -178,6 +178,10 @@ public class WorkbookAssistantFrame extends JFrame {
         c.gridx++;
         RemoveScramblesAction removeScramblesAction = new RemoveScramblesAction(fEnv, scramblesFilesTextField);
         panel.add(new JButton(removeScramblesAction), c);
+        
+        c.gridx++;
+        EditScramblesAction editScramblesAction = new EditScramblesAction(fEnv);
+        panel.add(new JButton(editScramblesAction), c);
 
         return panel;
     }

--- a/src/main/java/org/worldcubeassociation/ui/tree/RoundScramblesTreeNode.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/RoundScramblesTreeNode.java
@@ -1,0 +1,15 @@
+package org.worldcubeassociation.ui.tree;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import org.worldcubeassociation.workbook.scrambles.RoundScrambles;
+
+public class RoundScramblesTreeNode extends DefaultMutableTreeNode {
+    
+    public final RoundScrambles roundScrambles;
+    public RoundScramblesTreeNode(RoundScrambles roundScrambles) {
+        super(String.format("Round %s", roundScrambles.getRoundId()));
+        this.roundScrambles = roundScrambles;
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/tree/ScrambleEventTreeNode.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/ScrambleEventTreeNode.java
@@ -1,0 +1,11 @@
+package org.worldcubeassociation.ui.tree;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+public class ScrambleEventTreeNode extends DefaultMutableTreeNode {
+
+    public ScrambleEventTreeNode(String event) {
+        super(event);
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/tree/ScrambleSourceTreeNode.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/ScrambleSourceTreeNode.java
@@ -1,0 +1,11 @@
+package org.worldcubeassociation.ui.tree;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+public class ScrambleSourceTreeNode extends DefaultMutableTreeNode {
+
+    public ScrambleSourceTreeNode(String string) {
+        super(string);
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/tree/ScramblesTableModel.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/ScramblesTableModel.java
@@ -1,0 +1,76 @@
+package org.worldcubeassociation.ui.tree;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.HashMap;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+
+import org.worldcubeassociation.WorkbookAssistantEnv;
+import org.worldcubeassociation.workbook.scrambles.Events;
+import org.worldcubeassociation.workbook.scrambles.RoundScrambles;
+import org.worldcubeassociation.workbook.scrambles.Rounds;
+import org.worldcubeassociation.workbook.scrambles.Scrambles;
+import org.worldcubeassociation.workbook.scrambles.TNoodleSheetJson;
+
+public class ScramblesTableModel extends DefaultTreeModel implements PropertyChangeListener {
+
+    private final WorkbookAssistantEnv env;
+    
+    public ScramblesTableModel(WorkbookAssistantEnv env) {
+        super(new DefaultMutableTreeNode("All scrambles", true));
+        this.env = env;
+        env.addPropertyChangeListener(this);
+    }
+
+    private void recreateTree() {
+        DefaultMutableTreeNode root = (DefaultMutableTreeNode) getRoot();
+        root.removeAllChildren();
+        
+        Scrambles scrambles = env.getScrambles();
+        if(scrambles == null) {
+            return;
+        }
+        
+        HashMap<File, Events> eventsBySource = scrambles.eventsBySource;
+        for(File source : eventsBySource.keySet()) {
+            Events events = eventsBySource.get(source);
+            ScrambleSourceTreeNode sourceNode = new ScrambleSourceTreeNode(source.getAbsolutePath());
+            root.add(sourceNode);
+            HashMap<String, Rounds> roundsByEvent = events.roundsByEvent;
+            for(String event : roundsByEvent.keySet()) {
+                Rounds rounds = roundsByEvent.get(event);
+                ScrambleEventTreeNode eventNode = new ScrambleEventTreeNode(event);
+                sourceNode.add(eventNode);
+                for(RoundScrambles rs : rounds.asList()) {
+                    HashMap<String, TNoodleSheetJson> sheetsByGroupId = rs.getSheetsByGroupId();
+                    RoundScramblesTreeNode roundNode = new RoundScramblesTreeNode(rs);
+                    eventNode.add(roundNode);
+                    for(String groupId : sheetsByGroupId.keySet()) {
+                        TNoodleSheetJson sheet = sheetsByGroupId.get(groupId);
+                        SheetScramblesTreeNode sheetNode = new SheetScramblesTreeNode(sheet, rs);
+                        roundNode.add(sheetNode);
+                    }
+                }
+            }
+        }
+        
+        // Oh, Java, I don't miss you anymore: https://bugs.openjdk.java.net/browse/JDK-8013571
+        fireTreeStructureChanged(this, new Object[] { root.getPath() }, new int[] { 0 }, new DefaultMutableTreeNode[] { root });
+    }
+
+    @Override
+    public boolean isLeaf(Object n) {
+        return n instanceof SheetScramblesTreeNode;
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (WorkbookAssistantEnv.SCRAMBLES.equals(e.getPropertyName())) {
+            recreateTree();
+        }
+    }
+
+}

--- a/src/main/java/org/worldcubeassociation/ui/tree/SheetScramblesTreeNode.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/SheetScramblesTreeNode.java
@@ -1,0 +1,26 @@
+package org.worldcubeassociation.ui.tree;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import org.worldcubeassociation.workbook.scrambles.RoundScrambles;
+import org.worldcubeassociation.workbook.scrambles.TNoodleSheetJson;
+
+public class SheetScramblesTreeNode extends DefaultMutableTreeNode {
+
+    public final TNoodleSheetJson sheet;
+    public RoundScrambles round;
+    public SheetScramblesTreeNode(TNoodleSheetJson sheet, RoundScrambles round) {
+        super(sheet.title + " from " + sheet.originalSource.getAbsolutePath());
+        this.sheet = sheet;
+        this.round = round;
+    }
+
+    public SheetScramblesTreeNode(SheetScramblesTreeNode node) {
+        this(node.sheet, node.round);
+    }
+    
+    public boolean representsSameSheet(SheetScramblesTreeNode node) {
+        return node.sheet == this.sheet && node.round == this.round;
+    }
+    
+}

--- a/src/main/java/org/worldcubeassociation/ui/tree/TreeDragAndDrop.java
+++ b/src/main/java/org/worldcubeassociation/ui/tree/TreeDragAndDrop.java
@@ -1,0 +1,291 @@
+package org.worldcubeassociation.ui.tree;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.swing.DropMode;
+import javax.swing.JComponent;
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.TransferHandler;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
+
+import org.worldcubeassociation.WorkbookAssistantEnv;
+import org.worldcubeassociation.workbook.WorkbookValidator;
+import org.worldcubeassociation.workbook.scrambles.InvalidSheetException;
+import org.worldcubeassociation.workbook.scrambles.RoundScrambles;
+
+/**
+ * Copied from http://stackoverflow.com/a/4589122/1739415, with some changes.
+ */
+public class TreeDragAndDrop {
+
+    private final JScrollPane content;
+    private final JTree tree;
+    private final WorkbookAssistantEnv fEnv;
+
+    public TreeDragAndDrop(WorkbookAssistantEnv env) {
+        fEnv = env;
+        tree = new JTree(new ScramblesTableModel(env)) {
+            @Override
+            public int getVisibleRowCount() {
+                // This is used as a hint for the surrounding JScrollPane.
+                // We'd like to show all our rows whenever possible.
+                return getRowCount();
+            }
+        };
+        tree.setDragEnabled(true);
+        tree.setDropMode(DropMode.INSERT);
+        tree.setTransferHandler(new TreeTransferHandler(fEnv));
+        tree.getSelectionModel().setSelectionMode(
+                TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+        content = new JScrollPane(tree);
+        
+        // If we don't force the vertical scroll bar to always be visible, then packing
+        // will size us large enough that we don't need any scrollbars, and then our
+        // NicelySizedJDialog will resize us to fit on the screen, which will induce
+        // a vertical scrollbar, and therefore, a horizontal scrollbar as well
+        // (because we didn't allocate enough X space for a vertical scrollbar when
+        // everything fit).
+        content.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
+    }
+    
+    public JScrollPane getContent() {
+        return content;
+    }
+
+    public void expandTree() {
+        DefaultMutableTreeNode root =
+            (DefaultMutableTreeNode)tree.getModel().getRoot();
+        Enumeration e = root.breadthFirstEnumeration();
+        while(e.hasMoreElements()) {
+            DefaultMutableTreeNode node =
+                (DefaultMutableTreeNode) e.nextElement();
+            if(node.isLeaf()) continue;
+            int row = tree.getRowForPath(new TreePath(node.getPath()));
+            tree.expandRow(row);
+        }
+    }
+    
+}
+
+class TreeTransferHandler extends TransferHandler {
+    DataFlavor nodesFlavor;
+    DataFlavor[] flavors = new DataFlavor[1];
+    LinkedList<DefaultMutableTreeNode> toRemove = new LinkedList<DefaultMutableTreeNode>();
+    private final WorkbookAssistantEnv fEnv;
+
+    public TreeTransferHandler(WorkbookAssistantEnv env) {
+        fEnv = env;
+        try {
+            String mimeType = DataFlavor.javaJVMLocalObjectMimeType +
+                              ";class=\"" +
+                javax.swing.tree.DefaultMutableTreeNode[].class.getName() +
+                              "\"";
+            nodesFlavor = new DataFlavor(mimeType);
+            flavors[0] = nodesFlavor;
+        } catch(ClassNotFoundException e) {
+            System.out.println("ClassNotFound: " + e.getMessage());
+        }
+    }
+
+    public boolean canImport(TransferHandler.TransferSupport support) {
+        if(!support.isDrop()) {
+            return false;
+        }
+        support.setShowDropLocation(true);
+        if(!support.isDataFlavorSupported(nodesFlavor)) {
+            return false;
+        }
+        JTree.DropLocation dl =
+                (JTree.DropLocation) support.getDropLocation();
+        JTree tree = (JTree) support.getComponent();
+        
+        // Only allow selected nodes to move to other locations at the same depth.
+        // It is sufficient to look at the first selected node, as we only allow selections
+        // where every node is at the same depth.
+        TreePath selectionPath = tree.getSelectionPath();
+        if(dl.getPath().getPath().length != selectionPath.getPath().length - 1) {
+            return false;
+        }
+                
+        int action = support.getDropAction();
+        if(action == MOVE) {
+            return canMoveNodes(tree);
+        }
+        // The only action we allow is MOVE
+        return false;
+    }
+
+    private boolean canMoveNodes(JTree tree) {
+        int[] selRows = tree.getSelectionRows();
+        for(int selRow : selRows) {
+            TreePath path = tree.getPathForRow(selRow);
+            DefaultMutableTreeNode node =
+                    (DefaultMutableTreeNode) path.getLastPathComponent();
+            int childCount = node.getChildCount();
+            if(childCount > 0) {
+                // Do not allow movement of non leaf nodes.
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected Transferable createTransferable(JComponent c) {
+        JTree tree = (JTree) c;
+        TreePath[] paths = tree.getSelectionPaths();
+        if(paths != null) {
+            // Make up a node array of copies for transfer and
+            // another for/of the nodes that will be removed in
+            // exportDone after a successful drop.
+            List<DefaultMutableTreeNode> copies =
+                new ArrayList<DefaultMutableTreeNode>();
+            toRemove.clear();
+
+            for(TreePath path : paths) {
+                DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+                if(!(node instanceof SheetScramblesTreeNode)) {
+                    return null;
+                }
+                SheetScramblesTreeNode gsNode = (SheetScramblesTreeNode) node;
+                copies.add(copy(gsNode));
+                toRemove.add(gsNode);
+            }
+            DefaultMutableTreeNode[] nodes =
+                copies.toArray(new DefaultMutableTreeNode[copies.size()]);
+            return new NodesTransferable(nodes);
+        }
+        return null;
+    }
+
+    private SheetScramblesTreeNode copy(SheetScramblesTreeNode node) {
+        return new SheetScramblesTreeNode(node);
+    }
+
+    protected void exportDone(JComponent source, Transferable data, int action) {
+        if((action & MOVE) == MOVE) {
+            JTree tree = (JTree) source;
+            DefaultTreeModel model = (DefaultTreeModel) tree.getModel();
+            // Remove nodes saved in toRemove during createTransferable().
+            for(DefaultMutableTreeNode node : toRemove) {
+                model.removeNodeFromParent(node);
+            }
+            WorkbookValidator.validate(fEnv.getMatchedWorkbook(), fEnv.getDatabase(), fEnv.getScrambles());
+            fEnv.fireSheetsChanged();
+        }
+    }
+
+    public int getSourceActions(JComponent c) {
+        return MOVE;
+    }
+
+    public boolean importData(TransferHandler.TransferSupport support) {
+        if(!canImport(support)) {
+            return false;
+        }
+        // Extract transfer data.
+        DefaultMutableTreeNode[] nodes = null;
+        try {
+            Transferable t = support.getTransferable();
+            nodes = (DefaultMutableTreeNode[]) t.getTransferData(nodesFlavor);
+        } catch(UnsupportedFlavorException ufe) {
+            ufe.printStackTrace();
+        } catch(java.io.IOException ioe) {
+            ioe.printStackTrace();
+        }
+        // Get drop location info.
+        JTree.DropLocation dl =
+                (JTree.DropLocation) support.getDropLocation();
+        int childIndex = dl.getChildIndex();
+        TreePath dest = dl.getPath();
+        DefaultMutableTreeNode parent =
+            (DefaultMutableTreeNode) dest.getLastPathComponent();
+        JTree tree = (JTree)support.getComponent();
+        DefaultTreeModel model = (DefaultTreeModel) tree.getModel();
+        // Configure for drop mode.
+        int index = childIndex;    // DropMode.INSERT
+        if(childIndex == -1) {     // DropMode.ON
+            index = parent.getChildCount();
+        }
+        // Add data to model.
+        RoundScrambles newRound = ((RoundScramblesTreeNode) parent).roundScrambles;
+        for(int i = 0; i < nodes.length; i++) {
+            SheetScramblesTreeNode node = (SheetScramblesTreeNode) nodes[i];
+            RoundScrambles oldRound = node.round;
+            if(oldRound == newRound) {
+                // Attempting to actually do the move from oldRound to newRound
+                // would result in an InvalidSheetException due to a duplicate sheet.
+                // We do want to continue on to the call to insertNodeInto() below, though.
+                // This lets people reorder groups within rounds.
+            } else {
+                try {
+                    newRound.addSheet(node.sheet);
+                    // Note that we only remove the sheet from oldRound if we successfully
+                    // added it to newRound.
+                    oldRound.removeSheet(node.sheet);
+                    node.round = newRound;
+                } catch(InvalidSheetException e) {
+                    // We've failed to move this sheet. We don't want to lose the original node, so
+                    // we must remove the original node from the toRemove list.
+                    boolean found = false;
+                    for(ListIterator<DefaultMutableTreeNode> iter = toRemove.listIterator(); iter.hasNext(); ) {
+                        SheetScramblesTreeNode nodeToRemove = (SheetScramblesTreeNode) iter.next();
+                        if(nodeToRemove.representsSameSheet(node)) {
+                            iter.remove();
+                            found = true;
+                            break;
+                        }
+                    }
+                    e.printStackTrace();
+                    JOptionPane.showMessageDialog(null, e.getMessage(),
+                            "Unable to move sheet from " + oldRound + " to " + newRound, JOptionPane.ERROR_MESSAGE);
+                    if(!found) {
+                        JOptionPane.showMessageDialog(null, "Something really bad happened while cancelling the move.",
+                                "Uh oh", JOptionPane.ERROR_MESSAGE);
+                    }
+                    continue;
+                }
+            }
+            model.insertNodeInto(node, parent, index++);
+        }
+        return true;
+    }
+
+    public String toString() {
+        return getClass().getName();
+    }
+
+    public class NodesTransferable implements Transferable {
+        DefaultMutableTreeNode[] nodes;
+
+        public NodesTransferable(DefaultMutableTreeNode[] nodes) {
+            this.nodes = nodes;
+         }
+
+        public Object getTransferData(DataFlavor flavor)
+                                 throws UnsupportedFlavorException {
+            if(!isDataFlavorSupported(flavor))
+                throw new UnsupportedFlavorException(flavor);
+            return nodes;
+        }
+
+        public DataFlavor[] getTransferDataFlavors() {
+            return flavors;
+        }
+
+        public boolean isDataFlavorSupported(DataFlavor flavor) {
+            return nodesFlavor.equals(flavor);
+        }
+    }
+}

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/Events.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/Events.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 
 public class Events {
 
-	private final HashMap<String, Rounds> roundsByEvent;
+	public final HashMap<String, Rounds> roundsByEvent;
 	private final File source;
 	
 	public Events(File source) {
@@ -41,4 +41,5 @@ public class Events {
 	public Rounds getRoundsForEventIfExists(String eventId) {
 		return roundsByEvent.get(eventId);
 	}
+
 }

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/RoundScrambles.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/RoundScrambles.java
@@ -44,4 +44,12 @@ public class RoundScrambles {
 		return roundId;
 	}
 
+    public void removeSheet(TNoodleSheetJson sheet) throws InvalidSheetException {
+        TNoodleSheetJson candidateSheet = sheetsByGroupId.get(sheet.group);
+        if(candidateSheet != sheet) {
+            throw new InvalidSheetException("Sheet " + sheet.toString() + " not found in " + toString());
+        }
+        sheetsByGroupId.remove(sheet.group);
+    }
+
 }

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/ScrambleDecoder.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/ScrambleDecoder.java
@@ -46,7 +46,7 @@ public class ScrambleDecoder {
                 ZipInputStream is = zipFile.getInputStream(jsonFileHeader);
 
                 try {
-                    TNoodleScramblesJson tNoodleScramblesJson = parseJsonScrambles(is, aScrambleFile.getAbsolutePath());
+                    TNoodleScramblesJson tNoodleScramblesJson = parseJsonScrambles(is, aScrambleFile);
                     is.close();
                     return new DecodedScrambleFile(aScrambleFile, tNoodleScramblesJson);
                 } catch (IOException e) {
@@ -58,7 +58,7 @@ public class ScrambleDecoder {
         } else if (ext.endsWith(".json")) {
             try {
                 FileInputStream fis = new FileInputStream(aScrambleFile);
-                TNoodleScramblesJson tNoodleScramblesJson = parseJsonScrambles(fis, aScrambleFile.getAbsolutePath());
+                TNoodleScramblesJson tNoodleScramblesJson = parseJsonScrambles(fis, aScrambleFile);
                 fis.close();
                 return new DecodedScrambleFile(aScrambleFile, tNoodleScramblesJson);
             } catch (FileNotFoundException e) {
@@ -86,11 +86,14 @@ public class ScrambleDecoder {
         }
     }
 
-    private static TNoodleScramblesJson parseJsonScrambles(InputStream is, String filename) throws InvalidScramblesFileException {
+    private static TNoodleScramblesJson parseJsonScrambles(InputStream is, File source) throws InvalidScramblesFileException {
         InputStreamReader isr = new InputStreamReader(is);
         TNoodleScramblesJson scrambles = GSON.fromJson(isr, TNoodleScramblesJson.class);
         if (scrambles.sheets == null) {
-            throw new InvalidScramblesFileException("sheets attribute not found in " + filename);
+            throw new InvalidScramblesFileException("sheets attribute not found in " + source.getAbsolutePath());
+        }
+        for(TNoodleSheetJson sheet : scrambles.sheets) {
+            sheet.originalSource = source;
         }
         return scrambles;
     }

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/Scrambles.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/Scrambles.java
@@ -17,7 +17,7 @@ import java.util.SortedMap;
 public class Scrambles {
 
     private List<DecodedScrambleFile> decodedScrambleFiles;
-	private HashMap<File, Events> eventsBySource;
+	public HashMap<File, Events> eventsBySource;
 	private Events mergedSources;
 	private String scrambleProgram;
 
@@ -30,23 +30,10 @@ public class Scrambles {
         return decodedScrambleFiles;
     }
 
-    public String getScramblesSources() {
-		if(eventsBySource == null) {
-			return "";
-		}
-
-		StringBuilder sb = new StringBuilder();
-		for(File src : eventsBySource.keySet()) {
-			sb.append(" ").append(src);
-		}
-		int offset = sb.length() > 0 ? 1 : 0;
-		return sb.substring(offset);
-	}
-
 	public String getScrambleProgram() {
 		return scrambleProgram;
 	}
-
+	
     private void updateEvents() throws InvalidScramblesFileException {
         eventsBySource = new HashMap<File, Events>();
         scrambleProgram = null;

--- a/src/main/java/org/worldcubeassociation/workbook/scrambles/TNoodleSheetJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/scrambles/TNoodleSheetJson.java
@@ -1,5 +1,7 @@
 package org.worldcubeassociation.workbook.scrambles;
 
+import java.io.File;
+
 import org.worldcubeassociation.workbook.MatchedSheet;
 import org.worldcubeassociation.workbook.wcajson.WcaGroupJson;
 
@@ -13,6 +15,12 @@ public class TNoodleSheetJson {
 	public String group;
 	public String event;
 	public int round;
+	
+	// This doesn't come from TNoodle's json. We manually add it after parsing the JSON.
+	// This lets us always correctly identify TNoodleSheetJson's, even after the user has
+	// edited scrambles (moving TNoodleSheetJson's to different Rounds, possibly from different
+	// sources).
+	public File originalSource;
 	
 	public WcaGroupJson toWcaSheetJson(MatchedSheet matchedSheet) {
 		WcaGroupJson wcaSheet = new WcaGroupJson();


### PR DESCRIPTION
I added a TEST_SCRAMBLE_FILES variable to WorkbookAssistantFrame.java to speed up development.

I changed the event string for SCRAMBLES in WorkbookAssistantEnv.java, this should reduce activity when scrambles change. Hopefully it doesn't introduce any bugs.

The meat of this diff is the addition of a dialog to edit scrambles (accessible via an "Edit" button next to the add and remove scrambles buttons). Full disclosure: I haven't tested this very extensively (specifically, I haven't tried adding or removing scramble sources, nor have I actually checked the resulting JSON to see if it reflects the changes I've made), but what testing I have done seems to work.

One big issue: Right now, the workbook assistant refuses to put multiple groups in a Round with the same groupId (see https://github.com/cubing/wca-workbook-assistant/blob/master/src/main/java/org/worldcubeassociation/workbook/scrambles/RoundScrambles.java#L26). There's nothing in the JSON 0.2 version (see #48) that requires this, although I bet James & the website don't support groups in a round with the same groupId. The reason this is important is because the wca-workbook-assistant's enforcement that groups in a round don't have the same groupId makes moving sheets between rounds impossible in most cases (you almost always get groupId collisions!). I don't believe the correct fix is to relax the wca-workbook-assistant's requirement, I think it's a good thing to have. Instead, I think we need to expand upon the work I've done here to let people change the groupIds for sheets. That way, people will not be blocked from moving sheets to where they need them to go.

One last comment: I chose not to require that if you're moving a sheet from a round of event Foo, that you drop it into a round that is also of event Foo. I figured it's possible that people maybe generate 333 scrambles for an extra round of 333oh, and will need to move sheets between the two events. Thoughts on this are appreciated!
