### PR TITLE
Three small improvements

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,7 @@
         <jar basedir="target/classes" jarfile="target/wca-workbook-assistant-lib-${version}.jar">
             <manifest>
                 <attribute name="Main-Class" value="org.worldcubeassociation.WorkbookAssistant"/>
+                <attribute name="Implementation-Version" value="${version}"/>
             </manifest>
         </jar>
     </target>

--- a/src/main/java/org/worldcubeassociation/db/Persons.java
+++ b/src/main/java/org/worldcubeassociation/db/Persons.java
@@ -31,7 +31,7 @@ public class Persons {
         List<Person> existingPersons = new ArrayList<Person>();
         Collection<Person> persons = fPersons.values();
         for (Person person : persons) {
-            if (aName.endsWith(person.getName()) && aCountry.equals(person.getCountry())) {
+            if (aName.equals(person.getName()) && aCountry.equals(person.getCountry())) {
                 existingPersons.add(person);
             }
         }

--- a/src/main/java/org/worldcubeassociation/workbook/JSONGenerator.java
+++ b/src/main/java/org/worldcubeassociation/workbook/JSONGenerator.java
@@ -6,6 +6,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Row;
+import org.worldcubeassociation.WorkbookAssistant;
 import org.worldcubeassociation.db.Database;
 import org.worldcubeassociation.workbook.parse.CellParser;
 import org.worldcubeassociation.workbook.parse.RowTokenizer;
@@ -44,6 +45,7 @@ public class JSONGenerator {
         competitionJson.formatVersion = aVersion.toString();
         competitionJson.events = generateEvents(aMatchedWorkbook);
         competitionJson.scrambleProgram = scrambles == null ? null : scrambles.getScrambleProgram();
+        competitionJson.resultsProgram = "WCA Workbook Assistant v" + WorkbookAssistant.class.getPackage().getImplementationVersion();
         return GSON.toJson(competitionJson);
     }
 

--- a/src/main/java/org/worldcubeassociation/workbook/JSONGenerator.java
+++ b/src/main/java/org/worldcubeassociation/workbook/JSONGenerator.java
@@ -24,7 +24,7 @@ import java.util.*;
  */
 public class JSONGenerator {
 
-    public static final JSONVersion DEFAULT_VERSION = JSONVersion.WCA_COMPETITION_0_2;
+    public static final JSONVersion DEFAULT_VERSION = JSONVersion.WCA_COMPETITION_0_3;
     public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
     public static String generateJSON(MatchedWorkbook aMatchedWorkbook, String aCompetitionId, Scrambles scrambles, Database aDatabase) throws ParseException {
@@ -32,7 +32,7 @@ public class JSONGenerator {
     }
 
     public static String generateJSON(MatchedWorkbook aMatchedWorkbook, String aCompetitionId, Scrambles scrambles, Database aDatabase, JSONVersion aVersion) throws ParseException {
-        if (aVersion != JSONVersion.WCA_COMPETITION_0_2) {
+        if (aVersion != JSONVersion.WCA_COMPETITION_0_3) {
             throw new IllegalArgumentException("Unsupported version: " + aVersion);
         }
 

--- a/src/main/java/org/worldcubeassociation/workbook/JSONVersion.java
+++ b/src/main/java/org/worldcubeassociation/workbook/JSONVersion.java
@@ -6,7 +6,8 @@ package org.worldcubeassociation.workbook;
 public enum JSONVersion {
 
     WCA_COMPETITION_0_1("WCA Competition 0.1"),
-    WCA_COMPETITION_0_2("WCA Competition 0.2");
+    WCA_COMPETITION_0_2("WCA Competition 0.2"),
+    WCA_COMPETITION_0_3("WCA Competition 0.3");
 
     private String fName;
 

--- a/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaCompetitionJson.java
+++ b/src/main/java/org/worldcubeassociation/workbook/wcajson/WcaCompetitionJson.java
@@ -9,4 +9,5 @@ public class WcaCompetitionJson {
 	public WcaPersonJson[] persons;
 	public WcaEventJson[] events;
 	public String scrambleProgram;
+	public String resultsProgram;
 }


### PR DESCRIPTION
* New validation for the registration sheet --filter for false newcomers.  If there's a perfect match in name and country with an existing person and the WCA ID is missing, WA gives a *low severity validation error*.
* New validation for the registration sheet --dates of birth are checked to give ages between 5 and 90 years.  Otherwise, a *low severity validation error* is added.
* The WA version is added to the JSON output in a new `resultsProgram` field.